### PR TITLE
Fix wrong callback call in requestCredential

### DIFF
--- a/apple_client.js
+++ b/apple_client.js
@@ -87,7 +87,7 @@ Apple.requestCredential = function(options, nativeCallback, oauthCallback) {
         },
         function(err) {
             console.error("err", err);
-            callback(err, null);
+            credentialRequestCompleteCallback(err);
         }
     );
 };


### PR DESCRIPTION
The function `callback` does not exist in the function `requestCredential` in the file `apple_client.js`. I think that `callback` has to be `credentialRequestCompleteCallback`. 

This results in a thrown error (`ReferenceError: Can't find variable: callback`). The consequence is that my UI is not working as expected when a user clicks on "Login with Apple" and cancels the appearing native popup.

### Replication
1. You have to use this package (correctly configured with functioning login button) in a Meteor project with Cordova.
2. Install the Cordova App on an actual Apple device.
3. Use the Apple login button.
4. Press "Cancel" on the appearing native popup.
5. An error regarding the non existing `callback` is thrown.