### PR TITLE
[feat] - Add support for react-native apple sign in.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### V.3.0.1
+
+Add new endpoint for web-based authentication ("web-apple") for clients other than Cordova.
+
 ### v3.0.0
 
 We don't have breaking changes in this version.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,54 @@ And log in calling:
   });
 ```
 
+### Login without Cordova
+
+If you are using `react-native` or any other tool besides Cordova, you can also use this library.
+You just need to fetch the credentials from Apple, and then send it to the Meteor server:
+```
+Meteor.call(
+          "login",
+          {
+            ...credentials,
+            code: credentials[supportsIos ? 'authorizationCode' : 'code'],
+            methodName: `${supportsIos ? 'native' : 'web'}-apple`,
+          }, (err) => {...})
+```
+
+## React-native
+In react native you could log in using `invertase/react-native-apple-authentication` and `meteorrn/core`:
+```
+Meteor.loginWithApple = async () => {
+    const credentials = await appleAuth.performRequest({
+    requestedOperation: appleAuth.Operation.LOGIN,
+    requestedScopes: [appleAuth.Scope.FULL_NAME, appleAuth.Scope.EMAIL],
+  });
+  
+  return new Promise((resolve, reject) => {
+      Meteor._startLoggingIn();
+      Meteor.call(
+          "login",
+          {
+            ...credentials,
+            code: credentials.authorizationCode,
+            // For android you need to use 'web-apple' as the method name.
+            methodName: 'native-apple',
+          },
+          (error: any, response: unknown) => {
+            Meteor._endLoggingIn();
+            Meteor._handleLoginCallback(error, response);
+
+            if (error) {
+              return reject(error);
+            }
+
+            resolve(response);
+          }
+      );
+    });
+}
+```
+
 ## Use multiple services ids
 
 Because of a limitation imposed by apple, organization accounts can set up to 100 domains+redirect urls, and individuals only 10.

--- a/apple_server.js
+++ b/apple_server.js
@@ -185,7 +185,7 @@ function getAbsoluteUrlOptions(query) {
  *
  * @param {*} query auth/authorize redirect response from apple
  */
-const getTokens = (query, isNative = false) => {
+const getTokens = ({query, isNative = false}) => {
   const endpoint = 'https://appleid.apple.com/auth/token';
   let state = {};
   try {
@@ -270,7 +270,7 @@ const getTokens = (query, isNative = false) => {
 
 const getServiceData = query =>
   getServiceDataFromTokens({
-    query, tokens: getTokens(query, false), isNative: false, isBeingCalledFromLoginHandler: false,
+    query, tokens: getTokens({query})
 });
 OAuth.registerService('apple', 2, null, getServiceData);
 Accounts.registerLoginHandler(query => {
@@ -281,6 +281,6 @@ Accounts.registerLoginHandler(query => {
 
   const isNative = methodName === METHOD_NAMES.NATIVE;
   return getServiceDataFromTokens({
-    query, tokens: getTokens(query, isNative), isNative, isBeingCalledFromLoginHandler: true
+    query, tokens: getTokens({query, isNative}), isNative, isBeingCalledFromLoginHandler: true
   });
 });

--- a/apple_server.js
+++ b/apple_server.js
@@ -67,9 +67,9 @@ const verifyAndParseIdentityToken = (query, idToken, isNative = false) =>
  * @param query
  * @param {*} tokens tokens and data from apple
  * @param isNative
- * @param fromLoginHandler
+ * @param isBeingCalledFromLoginHandler
  */
-const getServiceDataFromTokens = (query, tokens, isNative = false, fromLoginHandler = false) => {
+const getServiceDataFromTokens = (query, tokens, isNative = false, isBeingCalledFromLoginHandler = false) => {
   const { accessToken, idToken, expiresIn } = tokens;
   const scopes = 'name email';
 
@@ -109,7 +109,7 @@ const getServiceDataFromTokens = (query, tokens, isNative = false, fromLoginHand
     options.profile.name = tokens.user.name;
   }
 
-  if (fromLoginHandler) {
+  if (isBeingCalledFromLoginHandler) {
     return Accounts.updateOrCreateUserFromExternalService(
         'apple',
         serviceData,

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
     name: 'quave:apple-oauth',
-    version: '3.0.0',
+    version: '3.0.1',
     summary: 'Sign in with Apple OAuth flow - fork from bigowl',
     git: 'https://github.com/quavedev/apple-oauth',
 });

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
     name: 'quave:apple-oauth',
-    version: '3.0.1',
+    version: '3.1.0',
     summary: 'Sign in with Apple OAuth flow - fork from bigowl',
     git: 'https://github.com/quavedev/apple-oauth',
 });

--- a/utils.js
+++ b/utils.js
@@ -70,3 +70,8 @@ export function stateParam({
   // Use the 'base64' package here because 'btoa' isn't supported in IE8/9.
   return Base64.encode(JSON.stringify(state));
 }
+
+export const METHOD_NAMES = {
+  NATIVE: 'native-apple',
+  WEB: 'web-apple'
+}


### PR DESCRIPTION
Create new handler for login with react-native. While this was made thinking of react-native, it allows any front-end to use the package and correctly handle login, given that they handle the client-side credential fetching from apple.