### PR TITLE
Email fallback and remove whitespaces from name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### v3.1.1
+
+- Remove whitespaces from the fullName and only set it on `serviceData` if it's not empty.
+- Use `query.email` as a fallback.
+
 ### v3.1.0
 
 Add new endpoint for web-based authentication ("web-apple") for clients other than Cordova.

--- a/apple_server.js
+++ b/apple_server.js
@@ -88,10 +88,10 @@ const getServiceDataFromTokens = ({ query, tokens, isNative = false, isBeingCall
     idToken,
     scope: scopes,
     expiresAt: Date.now() + 1000 * parseInt(expiresIn, 10),
-    email: parsedIdToken.email,
+    email: parsedIdToken.email || query.email,
   };
 
-  // only set the token in serviceData if it's there. this ensures
+  // Only set the token in serviceData if it's there. this ensures
   // that we don't lose old ones (since we only get this on the first
   // log in attempt)
   if (tokens.refreshToken) {
@@ -100,7 +100,8 @@ const getServiceDataFromTokens = ({ query, tokens, isNative = false, isBeingCall
 
   const options = { profile: { email: serviceData.email } };
 
-  if (tokens.fullName) {
+  // Only set the fullName if it's not empty.
+  if (tokens.fullName && !/^\s*$/.test(tokens.fullName)) {
     serviceData.name = tokens.fullName;
     options.profile.name = tokens.fullName;
   }
@@ -114,7 +115,7 @@ const getServiceDataFromTokens = ({ query, tokens, isNative = false, isBeingCall
         'apple',
         serviceData,
         options
-    )
+    );
   }
 
   return {
@@ -262,7 +263,9 @@ const getTokens = ({query, isNative = false}) => {
             query.fullName.givenName,
             query.fullName.middleName,
             query.fullName.familyName,
-          ].join(' ')
+          ]
+              .filter(Boolean)
+              .join(' ')
         : '',
     };
   }

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
     name: 'quave:apple-oauth',
-    version: '3.1.0',
+    version: '3.1.1',
     summary: 'Sign in with Apple OAuth flow - fork from bigowl',
     git: 'https://github.com/quavedev/apple-oauth',
 });


### PR DESCRIPTION
 Remove whitespaces from full name when updating the user and use `query.email` as a fallback.