### PR TITLE
config.redirectUri should be first option for redirectUri

### DIFF
--- a/apple_client.js
+++ b/apple_client.js
@@ -48,10 +48,11 @@ Apple.requestCredential = function(options, oauthCallback, nativeCallback) {
         : 'name%20email';
 
     const redirectUri =
+      config.redirectUri ||
       (options &&
         options.absoluteUrlOptions &&
-        options.absoluteUrlOptions.rootUrl) ||
-      config.redirectUri;
+        options.absoluteUrlOptions.rootUrl);
+      
     const redirectUriWithOauth = redirectUri.includes('/_oauth/apple')
       ? redirectUri
       : `${redirectUri}${redirectUri.endsWith('/') ? '' : '/'}_oauth/apple`;


### PR DESCRIPTION
Hello,

If developer puts the 'redirectUri' on the 'loginServiceConfiguration', it seems he/she intends to use 'redirectUri' not 'rootUrl'.

It will be very helpful consider this.

Regrads,